### PR TITLE
allow for polyfill option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ testem.log
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add option to add include polyfills in build.
 
 ## [1.3.1]
 - Bumps ember-cli-qunit from 4.3.0 to 4.3.2.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ An addon to allow importing of [Luxon](https://moment.github.io/luxon/) in your 
 
 * `ember install ember-luxon`;
 
+Most modern browers will work fine with luxon. If you need to support legacy browsers you will need to include some polyfills.
+
+You can provide an option in your apps `ember-cli-build.js` file and we'll add [intl.js](https://github.com/andyearnshaw/Intl.js/) to your build.
+
+```js
+'ember-luxon': {
+  includeIntlPolyfill: true
+}
+```
+
+See the Luxon [support matrix](https://moment.github.io/luxon/docs/manual/matrix.html) for more information and which browsers support which features and other caveats.
+
 ## Usage
 
 ```js

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
   included(app) {
     this._super.included.apply(app, arguments);
 
-    const intlPath = path.join(resolve.sync('intl'), '..', 'dist', 'intl.js')
+    const intlPath = path.join(resolve.sync('intl'), '..', 'dist', 'Intl.js')
     const options = this.app.project.config(app.env)['ember-luxon'] || {};
 
     if (options.includeIntlPolyfill) {

--- a/index.js
+++ b/index.js
@@ -12,14 +12,21 @@ module.exports = {
   included(app) {
     this._super.included.apply(app, arguments);
 
+    const intlPath = path.join(resolve.sync('intl'), '..', 'dist', 'intl.js')
+    const options = this.app.project.config(app.env)['ember-luxon'] || {};
+
+    if (options.includeIntlPolyfill) {
+      app.import(intlPath);
+    }
+
     app.import('vendor/luxon.js');
   },
 
   treeForVendor(tree) {
-    const srcPath = path.join(resolve.sync('luxon'), '..', '..', '..', 'src');
+    const luxonPath = path.join(resolve.sync('luxon'), '..', '..', '..', 'src');
 
     let allTrees = [];
-    let rollupTree = new Rollup(srcPath, {
+    let rollupTree = new Rollup(luxonPath, {
       rollup: {
         input: 'luxon.js',
         output: {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "broccoli-rollup": "^2.0.0",
     "ember-cli-babel": "^6.11.0",
     "ember-cli-es6-transform": "^0.0.3",
+    "intl": "1.2.5",
     "luxon": "^0.4.0"
   },
   "devDependencies": {
@@ -37,16 +38,16 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-resolver": "^4.0.0",
     "ember-source": "~2.18.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "ember-welcome-page": "^3.0.0",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
-    "ember-load-initializers": "^1.0.0",
-    "ember-resolver": "^4.0.0",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/acceptance/intl-polyfill-test.js
+++ b/tests/acceptance/intl-polyfill-test.js
@@ -1,0 +1,10 @@
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+import { test } from 'qunit';
+
+moduleForAcceptance('Acceptance | Intl Polyfill');
+
+// This is enabled in the dummy environment file already.
+test('the polyfill is included when the option is provided', function(assert) {
+  assert.expect(1);
+  assert.ok(window.IntlPolyfill, 'intl polyfill was included')
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function(environment) {
     },
 
     'ember-luxon': {
-      includeIntlPolyfill: false
+      includeIntlPolyfill: true
     },
 
     APP: {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function(environment) {
     environment,
     rootURL: '/',
     locationType: 'auto',
+
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -15,6 +16,10 @@ module.exports = function(environment) {
         // Prevent Ember Data from overriding Date.parse.
         Date: false
       }
+    },
+
+    'ember-luxon': {
+      includeIntlPolyfill: false
     },
 
     APP: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3445,6 +3445,10 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+intl@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"


### PR DESCRIPTION
Allows for the user to include the intl polyfill when required by supplying an argument in the `ember-build-cli.js` file.

eg:

```js
'use strict';

module.exports = function(environment) {
  let ENV = {

   // some config

    'ember-luxon': {
      includeIntlPolyfill: false
    },
    
    // more config 
  };
}

```